### PR TITLE
chore: add spring-boot-devtools for automatic builds when developing

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -79,6 +79,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<!-- https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api -->
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>


### PR DESCRIPTION
This allows following workflow:

Developer starts intelliJ --> connects it to docker --> Trigger a build within the IDE; the application will automatically refresh inside the container without a full manual restart.