### PR TITLE
feat: validate numeric inputs in New Product dialog

### DIFF
--- a/backend/src/main/java/com/borsibaar/service/ProductService.java
+++ b/backend/src/main/java/com/borsibaar/service/ProductService.java
@@ -38,6 +38,10 @@ public class ProductService {
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.BAD_REQUEST, "Category not found: " + request.categoryId()));
 
+        if (request.minPrice().compareTo(request.maxPrice()) > 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Max price must be greater than min price");
+        }
+
         Product entity = productMapper.toEntity(request);
         entity.setOrganizationId(orgId);
         entity.setActive(true);

--- a/frontend/app/(protected)/(sidebar)/inventory/page.tsx
+++ b/frontend/app/(protected)/(sidebar)/inventory/page.tsx
@@ -45,6 +45,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 export const dynamic = "force-dynamic";
 
@@ -673,7 +674,12 @@ export default function Inventory() {
                     currentPrice: e.target.value,
                   })
                 }
-                className="w-full px-3 py-2 border border-gray-700 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className={cn(
+                                  "w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                                  Number(productForm.currentPrice) < 0
+                                    ? "border-red-600 text-[#FF6169]"
+                                    : "border-gray-700"
+                                )}
                 placeholder="0.00"
                 required
               />
@@ -693,7 +699,12 @@ export default function Inventory() {
                     minPrice: e.target.value,
                   })
                 }
-                className="w-full px-3 py-2 border border-gray-700 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className={cn(
+                                  "w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                                  Number(productForm.minPrice) < 0
+                                    ? "border-red-600 text-[#FF6169]"
+                                    : "border-gray-700"
+                                )}
                 placeholder="0.00"
                 required
               />
@@ -713,7 +724,12 @@ export default function Inventory() {
                     maxPrice: e.target.value,
                   })
                 }
-                className="w-full px-3 py-2 border border-gray-700 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className={cn(
+                                  "w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent",
+                                  Number(productForm.maxPrice) < 0 || Number(productForm.maxPrice) < Number(productForm.minPrice)
+                                    ? "border-red-600 text-[#FF6169]"
+                                    : "border-gray-700"
+                                )}
                 placeholder="0.00"
                 required
               />
@@ -778,7 +794,11 @@ export default function Inventory() {
                 !productForm.categoryId ||
                 !productForm.currentPrice ||
                 !productForm.minPrice ||
-                !productForm.maxPrice
+                !productForm.maxPrice ||
+                Number(productForm.currentPrice) < 0 ||
+                Number(productForm.minPrice) < 0 ||
+                Number(productForm.maxPrice) < 0 ||
+                Number(productForm.maxPrice) < Number(productForm.minPrice)
               }
               className="w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 transition font-medium disabled:bg-gray-700 disabled:cursor-not-allowed"
             >


### PR DESCRIPTION
In new item dialog, negative numeric inputs or max. price < min. price will display a visible warning, submit button will remain disabled until inputs are fixed by user.

Related to issue #7.

Note: this PR is essentially PR #25, with modified source.